### PR TITLE
Custom CA certificate support

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # DevEnv
-#DEV_IP={{ IP_HERE }}
+DEV_IP={{ IP_HERE }}
 CORE_DEBUG_LOGGING=no
 CORE_DEVELOPMENT_MODE=true
 CORE_CONFIG_SEED=file:/data/config/pylon.yml

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ REGEX_IFACE := ^[^[:space:]]*:
 REGEX_IPV4 := inet \K([0-9]{1,3}[\.]){3}[0-9]{1,3}
 IFCONFIG_CMD := /sbin/ifconfig
 UID := $(shell id -u)
-export UID 
+export UID
 
 SET_IP=$(shell $(IFCONFIG_CMD) $(INTERFACE) | grep -P -o "$(REGEX_IPV4)")
 GET_CENTRY_VOLUMES=$(shell docker volume ls -q | grep centry)
 
-.PHONY: all list_interfaces ip fix_permissions up down purge
-	
+.PHONY: all list_interfaces ip fix_permissions up down docker_volumes_prune
+
 all:
 	@echo Please read this info carefully for centry to properly work
 	@echo ===========================================================
@@ -21,7 +21,7 @@ all:
 	@echo More in README.md
 	@echo ----------------------------------------
 	@echo 2. Configure external DEV_IP in .env file
-	@echo To do so run \`make list_interfaces\` 
+	@echo To do so run \`make list_interfaces\`
 	@echo This will show list of interfaces and their corresponding ipv4
 	@echo Choose the interface through which you have access
 	@echo ------------------------------------------------------------------------
@@ -31,8 +31,19 @@ all:
 list_interfaces:
 	$(IFCONFIG_CMD) | grep -P -o "($(REGEX_IFACE)|$(REGEX_IPV4))"
 ip:
-	@echo  Setting DEV_IP in .env with ipv4 for \`$(INTERFACE)\` interface
-	$(eval IP=$(SET_IP))
+	@echo DIRECT_IP = $(DIRECT_IP)
+	@echo INTERFACE = $(INTERFACE)
+    ifneq ($(DIRECT_IP),)
+		@echo  Setting DEV_IP in .env to \`$(DIRECT_IP)\`
+		$(eval IP=$(DIRECT_IP))
+    else
+    ifneq ($(INTERFACE),)
+		@echo  Setting DEV_IP in .env with ipv4 for \`$(INTERFACE)\` interface
+		$(eval IP=$(SET_IP))
+    else
+		$(error "It is mandatory to set at least one of DIRECT_IP or INTERFACE environment variables! (e.g. `export INTERFACE=eth0` before calling `make up...`)")
+    endif
+    endif
 	sed -i -e "s+DEV_IP=.*+DEV_IP=$(IP)+g" .env
 	@echo DONE with IP=$(IP)
 
@@ -46,9 +57,77 @@ config/pylon.yml:
 up: fix_permissions ip config/pylon.yml
 	docker compose up -d
 
+up_with_custom_CA_cert: fix_permissions ip config/pylon.yml
+    ifneq ($(CUSTOM_CA_CERT),)
+		@echo Running docker compose with custom CA certificate file: $(CUSTOM_CA_CERT)
+		docker compose -f docker-compose.yaml -f docker-compose_custom_CA_cert.yaml up -d
+    else
+		@echo CUSTOM_CA_CERT environment variable is not set, aborting...
+    endif
+
+up_with_mitmproxy: ip
+	@(cp ~/.mitmproxy/mitmproxy-ca-cert.pem ./mitmproxy-ca-cert.pem)
+	docker compose create
+	$(MAKE) mitmproxy_iptables_register
+	CUSTOM_CA_CERT=./mitmproxy-ca-cert.pem $(MAKE) up_with_custom_CA_cert
+
 down:
 	docker compose down
 
-purge: down
+down_with_mitmproxy: mitmproxy_iptables_remove
+	docker compose down
+
+pylon_state_clean:
+	rm -rf ./pylon/plugins/*
+	rm -rf ./pylon/requirements/*
+
+pylon_auth_state_clean:
+	rm -rf ./pylon_auth/plugins/*
+	rm -rf ./pylon_auth/requirements/*
+
+pylon_worker_state_clean:
+	rm -rf ./pylon_worker/plugins/*
+	rm -rf ./pylon_worker/requirements/*
+
+docker_volumes_prune: down
 	docker volume rm $(GET_CENTRY_VOLUMES)
 
+clean_all:
+	$(MAKE) pylon_state_clean
+	$(MAKE) pylon_auth_state_clean
+	$(MAKE) pylon_worker_state_clean
+	$(MAKE) docker_volumes_prune
+
+docker_system_prune: down
+	docker system prune -a --volumes
+
+mitmproxy_interface_show:
+	$(IFCONFIG_CMD) | grep -P -o "$(REGEX_IFACE)" | grep -o -P "br-[^:]+"
+
+mitmproxy_iptables_register:
+	$(eval IF=$(shell $(IFCONFIG_CMD) | grep -P -o "$(REGEX_IFACE)" | grep -o -P "br-[^:]+"))
+	@echo Registering iptable rules to forward all traffic from $(IF) targeting ports 80/443 to mitmproxy...
+	@(sudo iptables -t nat -A PREROUTING -i $(IF) -p tcp --dport 80 -j REDIRECT --to-port 8080)
+	@(sudo iptables -t nat -A PREROUTING -i $(IF) -p tcp --dport 443 -j REDIRECT --to-port 8080)
+	@(sudo ip6tables -t nat -A PREROUTING -i $(IF) -p tcp --dport 80 -j REDIRECT --to-port 8080)
+	@(sudo ip6tables -t nat -A PREROUTING -i $(IF) -p tcp --dport 443 -j REDIRECT --to-port 8080)
+
+mitmproxy_iptables_remove:
+	$(eval IF=$(shell $(IFCONFIG_CMD) | grep -P -o "$(REGEX_IFACE)" | grep -o -P "br-[^:]+"))
+	@echo Removing iptable rules to forward all traffic from $(IF) targeting ports 80/443 to mitmproxy...
+	@(sudo iptables -t nat -D PREROUTING -i $(IF) -p tcp --dport 80 -j REDIRECT --to-port 8080)
+	@(sudo iptables -t nat -D PREROUTING -i $(IF) -p tcp --dport 443 -j REDIRECT --to-port 8080)
+	@(sudo ip6tables -t nat -D PREROUTING -i $(IF) -p tcp --dport 80 -j REDIRECT --to-port 8080)
+	@(sudo ip6tables -t nat -D PREROUTING -i $(IF) -p tcp --dport 443 -j REDIRECT --to-port 8080)
+
+mitmproxy_iptables_list:
+	@(sudo iptables -t nat -L -v --line-numbers | grep "redir ports 8080")
+	@(sudo ip6tables -t nat -L -v --line-numbers | grep "redir ports 8080")
+
+mitmproxy_start_transparent:
+	mitmproxy --mode transparent --showhost
+
+mitmproxy_prepare_system:
+	@(sudo sysctl -w net.ipv4.ip_forward=1)
+	@(sudo sysctl -w net.ipv6.conf.all.forwarding=1)
+	@(sudo sysctl -w net.ipv4.conf.all.send_redirects=0)

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,21 @@ mitmproxy_iptables_list:
 mitmproxy_start_transparent:
 	mitmproxy --mode transparent --showhost
 
+mitmdump_start_transparent:
+	mitmdump --mode transparent --showhost > mitmlog.log
+
+mitmdump_follow_all:
+	tail -f mitmlog.log
+
+mitmdump_follow_TLS_failed:
+	tail -f mitmlog.log | grep "TLS handshake failed"
+
+mitmdump_print_TLS_failed:
+	cat mitmlog.log | grep "TLS handshake failed"
+
+docker_print_IPs:
+	@docker inspect -f '{{.Name}} - {{.Config.Image}} - {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $$(docker ps -q)
+
 mitmproxy_prepare_system:
 	@(sudo sysctl -w net.ipv4.ip_forward=1)
 	@(sudo sysctl -w net.ipv6.conf.all.forwarding=1)

--- a/docker-compose_custom_CA_cert.yaml
+++ b/docker-compose_custom_CA_cert.yaml
@@ -42,7 +42,6 @@ services:
   mongo:
     volumes:
       - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
-    command: [ "docker-entrypoint.sh", "mongod", "--tlsCAFile=/etc/ssl/certs/custom-ca-cert.pem" ]
   interceptor:
     environment:
       SSL_CERT_FILE: /etc/ssl/certs/custom-ca-cert.pem

--- a/docker-compose_custom_CA_cert.yaml
+++ b/docker-compose_custom_CA_cert.yaml
@@ -1,0 +1,27 @@
+# Intended to be used together with the base docker-compose.yaml file for cases when a custom CA cert is needed for the system.
+# CUSTOM_CA_CERT env var must be set.
+# See an example usage at Makefile -> up_with_custom_CA_cert.
+
+version: '3'
+services:
+  pylon:
+    environment:
+      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+    volumes:
+      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+  pylon_auth:
+    environment:
+      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+    volumes:
+      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+  pylon_worker:
+    environment:
+      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+    volumes:
+      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro

--- a/docker-compose_custom_CA_cert.yaml
+++ b/docker-compose_custom_CA_cert.yaml
@@ -6,54 +6,54 @@ version: '3'
 services:
   pylon:
     environment:
-      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      SSL_CERT_FILE: /etc/ssl/certs/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
     volumes:
-      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   pylon_auth:
     environment:
-      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      SSL_CERT_FILE: /etc/ssl/certs/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
     volumes:
-      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   pylon_worker:
     environment:
-      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      SSL_CERT_FILE: /etc/ssl/certs/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
     volumes:
-      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   grafana:
     volumes:
-      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   traefik:
     volumes:
-      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   influx:
     volumes:
-      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   minio:
     environment:
       MINIO_SERVER_CA_CERTS_FILE: /etc/ssl/certs/custom-ca-cert.pem
     volumes:
-      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   mongo:
     volumes:
-      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
     command: [ "docker-entrypoint.sh", "mongod", "--tlsCAFile=/etc/ssl/certs/custom-ca-cert.pem" ]
   interceptor:
     environment:
-      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      SSL_CERT_FILE: /etc/ssl/certs/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
     volumes:
-      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro
   interceptor_internal:
     environment:
-      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
-      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      SSL_CERT_FILE: /etc/ssl/certs/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /etc/ssl/certs/custom-ca-cert.pem
     volumes:
-      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem:ro

--- a/docker-compose_custom_CA_cert.yaml
+++ b/docker-compose_custom_CA_cert.yaml
@@ -25,3 +25,35 @@ services:
       CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
     volumes:
       - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+  grafana:
+    volumes:
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+  traefik:
+    volumes:
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+  influx:
+    volumes:
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+  minio:
+    environment:
+      MINIO_SERVER_CA_CERTS_FILE: /etc/ssl/certs/custom-ca-cert.pem
+    volumes:
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+  mongo:
+    volumes:
+      - $CUSTOM_CA_CERT:/etc/ssl/certs/custom-ca-cert.pem
+    command: [ "docker-entrypoint.sh", "mongod", "--tlsCAFile=/etc/ssl/certs/custom-ca-cert.pem" ]
+  interceptor:
+    environment:
+      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+    volumes:
+      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro
+  interceptor_internal:
+    environment:
+      SSL_CERT_FILE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      REQUESTS_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+      CURL_CA_BUNDLE: /usr/local/share/ca-certificates/custom-ca-cert.pem
+    volumes:
+      - $CUSTOM_CA_CERT:/usr/local/share/ca-certificates/custom-ca-cert.pem:ro


### PR DESCRIPTION
Custom docker-compose and Makefile targets for starting carrier-io containers (that require internet access) with a custom CA certificate to be used by corporate clients if needed.
The above feature can be tested with mitmproxy to see that the custom CA cert of mitmproxy is picked up by the containers and the http(s) connections towards the internet are properly routed through mitmproxy and SSL handshake works. For more details see the targets added into the Makefile.

**Testing the changes**:

Prerequisites:
1. `git clone -b custom_ca_certificate https://github.com/attilavetesi
-epam/carrier-io-centry`
2. `git clone -b custom_ca_certificate https://github.com/attilavetesi-epam/carrier-io-pylon`
3. mitmproxy installed

Clean:
4. `cd carrier-io-centry`
5. `make clean_all`
6. optionally (to go with a full fresh start without cached images): `make docker_system_prune`

Build modified pylon image:
7. `cd  ../carrier-io-pylon`
8. `docker build -t getcarrier/pylon:latest .`

Prep centry:
9. `cd ../carrier-io-centry`
10. `make mitmproxy_prepare_system`
11. `export INTERFACE=eth0` (or any other interface that you want to bind to)

Test execution:
12. open a NEW terminal for the execution of mitmproxy as a parallel process in the background: `make mitmproxy_start_transparent`
13. (in the previous terminal where INTERFACE is set) `make up_with_mitmproxy`
14. while carrier-io boots up, watch **all the requests from the containers to the internet going through mitmproxy successfully**
15. wait until pylon loaded all the plugins (`docker logs -f carrier-pylon`)
16. open carrier-io, log in, create new project (use the email admin@centry.user), switch to project view and execute basic backend test: https://github.com/carrier-io/demo-jmeter (Entrypoint: BasicEcommerce.jmx)

