### PR TITLE
K8s fixes (2)

### DIFF
--- a/helm/carrier-io/templates/NOTES.txt
+++ b/helm/carrier-io/templates/NOTES.txt
@@ -1,1 +1,32 @@
-The application has been published on the root URL of the main ingress. Don't forget to set the same hostname/IP in the `values.yaml` file under the `global.app.host` entry. If access to carrier does not work, as a workaround, try to set up NodePort for traefik and connect to it directly (see the values.yaml for the traefik config).
+Carrier.io has been published on the root URL of the main ingress:
+------------------------------------
+    http://{{ .Values.global.app.host }}:{{ .Values.global.app.port }}/
+------------------------------------
+(If this is not correct, set the correct hostname/IP and port in the `values.yaml` file under the `global.app.host` and `global.app.port` entries.)
+
+
+In order to make this setup fully functional, some manual workarounds are required (until the codebase is potentially patched to change these defaults):
+
+1)
+Make components connect internally inside the cluster.
+In the Administration -> Secrets view, change the following secrets to the provided values:
+---------------------------------------------------------------------------------------------
+influx_ip       {{ .Values.influxdb.fullnameOverride }}
+loki_host       http://{{ .Values.services.loki.name }}   # it really has to be like this!
+rabbit_host     {{ .Values.rabbitmq.fullnameOverride }}
+
+2)
+For EACH project which is created, change the rabbitmq credentials so that job execution can correctly connect to it.
+After creating a project, in the Project -> Configuration -> Secrets view, change the following secrets to the provided values:
+-------------------------------------------------------------------------------------------------------------------------------
+rabbit_project_user         {{ .Values.rabbitmq.auth.username }}
+rabbit_project_password     {{ .Values.rabbitmq.auth.password }}
+rabbit_project_vhost        carrier
+
+3)
+Set up a new kubernetes integration in the Adminitration -> Integrations view or in the Project -> Configuration -> Integrations view
+in order to be able to execute jobs in your cluster, which requires dynamic provisioning through k8s API.
+For this, a new service account has to be created with adequate permissions and roles (or simply as an admin for testing purposes).
+Additionally, a new token is required for this service account, that can be provided to carrier.io.
+
+Happy continuous testing with carrier.io!

--- a/helm/carrier-io/templates/interceptor-internal-deployment.yaml
+++ b/helm/carrier-io/templates/interceptor-internal-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.services.interceptor_internal.name }}-deployment
+  labels:
+    {{- include "carrier-io.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "carrier-io.specificSelectorLabels" (dict "name" "interceptor" "release" .Release.Name) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "carrier-io.specificSelectorLabels" (dict "name" "interceptor" "release" .Release.Name) | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "carrier-io.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.services.interceptor_internal.name }}-container
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.images.interceptor.repository }}:{{ .Values.images.interceptor.tag }}"
+          imagePullPolicy: {{ .Values.images.interceptor.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.images.interceptor.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: env
+          env:
+            - name: CPU_CORES
+              valueFrom:
+                configMapKeyRef:
+                  name: env
+                  key: INTERPECTOR_TASKS_INTERNAL
+            - name: RABBIT_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: env
+                  key: RABBITMQ_PASSWORD
+            - name: RABBIT_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: env
+                  key: RABBITMQ_USER
+            - name: LOKI_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: env
+                  key: APP_HOST
+            - name: QUEUE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: env
+                  key: INTERNAL_QUEUE
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/carrier-io/values.yaml
+++ b/helm/carrier-io/values.yaml
@@ -39,6 +39,8 @@ services:
     targetPort: 8080
   interceptor:
     name: interceptor-carrier
+  interceptor_internal:
+    name: interceptor-internal-carrier
   loki:
     name: carrier-loki  # hostname is hardcoded in carrier, don't change this value until it's fixed
     type: ClusterIP
@@ -142,6 +144,10 @@ minio:
     - name: MINIO_API_SELECT_PARQUET
       value: "on"
   fullnameOverride: minio-carrier
+  persistence:
+    enabled: true
+    annotations:
+      "helm.sh/resource-policy": "keep"
 
 influxdb:
   setDefaultUser:


### PR DESCRIPTION
- Add interceptor_internal in order to fix job execution.
- Persist minio's storage across reboots.
- Add helm notes with the required manual workarounds to make the k8s deployment work (until the codebase is potentially extended to: 1. connect to components internally in the network instead of using the external IP by default; 2. make projects receive the correct rabbitmq credentials in the k8s case as well, just as in the case of docker).

Now, when you invoke helm install, it provides you a nice page with instructions on how to complete your k8s setup, with filled-in dynamic values.
Example below:
```
[user@host carrier-io/centry]$ helm install my-carrier-io ./helm/carrier-io --values ./helm/carrier-io/values.yaml
NAME: my-carrier-io
LAST DEPLOYED: Thu Jul 13 11:20:56 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Carrier.io has been published on the root URL of the main ingress:
------------------------------------
    http://172.26.108.95:80/
------------------------------------
(If this is not correct, set the correct hostname/IP and port in the `values.yaml` file under the `global.app.host` and `global.app.port` entries.)


In order to make this setup fully functional, some manual workarounds are required (until the codebase is potentially patched to change these defaults):

1)
Make components connect internally inside the cluster.
In the Administration -> Secrets view, change the following secrets to the provided values:
---------------------------------------------------------------------------------------------
influx_ip       influx-carrier
loki_host       http://carrier-loki   # it really has to be like this!
rabbit_host     carrier-rabbit

2)
For EACH project which is created, change the rabbitmq credentials so that job execution can correctly connect to it.
After creating a project, in the Project -> Configuration -> Secrets view, change the following secrets to the provided values:
-------------------------------------------------------------------------------------------------------------------------------
rabbit_project_user         user
rabbit_project_password     password
rabbit_project_vhost        carrier

3)
Set up a new kubernetes integration in the Adminitration -> Integrations view or in the Project -> Configuration -> Integrations view
in order to be able to execute jobs in your cluster, which requires dynamic provisioning through k8s API.
For this, a new service account has to be created with adequate permissions and roles (or simply as an admin for testing purposes).
Additionally, a new token is required for this service account, that can be provided to carrier.io.

Happy continuous testing with carrier.io!
```